### PR TITLE
[BUGFIX] Keep lines with @ sign in description

### DIFF
--- a/src/DocCommentParser.php
+++ b/src/DocCommentParser.php
@@ -24,13 +24,17 @@ class DocCommentParser
         $parsedDocComment = '';
         $lines = explode(chr(10), $docComment);
         foreach ($lines as $line) {
-            if (strlen($line) > 0 && strpos($line, '@') !== false) {
+            if ($this->isDocCommentTag($line)) {
                 continue;
-            } else {
-                $parsedDocComment .= preg_replace('/\\s*\\/?[\\\\*]*(.*)$/', '$1', $line) . chr(10);
             }
+            $parsedDocComment .= preg_replace('/\\s*\\/?[\\\\*]*(.*)$/', '$1', $line) . chr(10);
         }
         $parsedDocComment = trim($parsedDocComment);
         return $parsedDocComment;
+    }
+
+    private function isDocCommentTag(string $line)
+    {
+        return preg_match('/^\s*\*?\s*@/', $line) === 1;
     }
 }

--- a/tests/Unit/DocCommentParserTest.php
+++ b/tests/Unit/DocCommentParserTest.php
@@ -1,0 +1,76 @@
+<?php
+namespace TYPO3\FluidSchemaGenerator\Tests\Unit;
+
+/*
+ * This file belongs to the package "TYPO3 FluidSchemaGenerator".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use PHPUnit\Framework\TestCase;
+use TYPO3\FluidSchemaGenerator\DocCommentParser;
+
+/**
+ * Test case
+ */
+class DocCommentParserTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function returnsDescriptionWithoutTags()
+    {
+        $subject = new DocCommentParser();
+        $expected = implode(PHP_EOL, [
+            'Some Description',
+            '/',
+        ]);
+
+        $result = $subject->parseDocComment(implode(PHP_EOL, [
+            '/**',
+            ' * Some Description',
+            ' * @param string $someParam With some description',
+            ' */',
+        ]));
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function returnsDescriptionWithoutTagsContainingFurtherAtSign()
+    {
+        $subject = new DocCommentParser();
+        $expected = implode(PHP_EOL, [
+            'Some Description',
+            '/',
+        ]);
+
+        $result = $subject->parseDocComment(implode(PHP_EOL, [
+            '/**',
+            ' * Some Description',
+            ' * @param string $someParam With some description, containing @ sign',
+            ' */',
+        ]));
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function lineWithinDescriptionWithAtSignIsKept()
+    {
+        $subject = new DocCommentParser();
+        $expected = implode(PHP_EOL, [
+            'Some Description containing @ sign',
+            '/',
+        ]);
+
+        $result = $subject->parseDocComment(implode(PHP_EOL, [
+            '/**',
+            ' *',
+            ' * Some Description containing @ sign',
+            ' */',
+        ]));
+        $this->assertEquals($expected, $result);
+    }
+}


### PR DESCRIPTION
Add better detection whether line with @ is actual an php doc tag, or
whether @ sign appears within content of line.