### PR TITLE
[TASK] Add missing ViewHelper argument data type notation "bool"

### DIFF
--- a/src/SchemaGenerator.php
+++ b/src/SchemaGenerator.php
@@ -164,6 +164,7 @@ class SchemaGenerator
             case 'double':
                 return 'xsd:double';
             case 'boolean':
+            case 'bool':
                 return 'xsd:boolean';
             case 'string':
                 return 'xsd:string';

--- a/tests/Unit/SchemaGeneratorTest.php
+++ b/tests/Unit/SchemaGeneratorTest.php
@@ -59,6 +59,7 @@ class SchemaGeneratorTest extends TestCase
             ['float', 'xsd:float'],
             ['double', 'xsd:double'],
             ['boolean', 'xsd:boolean'],
+            ['bool', 'xsd:boolean'],
             ['string', 'xsd:string'],
             ['array', 'xsd:anySimpleType'],
             ['mixed', 'xsd:anySimpleType'],


### PR DESCRIPTION
According to `TYPO3Fluid\Fluid\Core\Parser\TemplateParser`, in addition to the data type `boolean`, `bool` is also treated as a boolean value. To prevent the ViewHelper documentation from outputting the data type `mixed` if the string `bool` was specified as a data type in the ViewHelper, it is necessary to adapt the XSD generation accordingly.