### PR TITLE
[TASK] Drop support for PHP < 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
+        php: ['8.1', '8.2', '8.3']
 
     steps:
       - uses: actions/checkout@v2
@@ -31,20 +31,10 @@ jobs:
         run: find src/ tests/ -name '*.php' -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null
 
       - name: Install dependencies
-        if: ${{ matrix.php <= '8.1' }}
         run: composer update
 
-      - name: Install dependencies PHP 8.2
-        # @todo: Needed until prophecy (req by phpunit) allows PHP 8.2, https://github.com/phpspec/prophecy/issues/556
-        if: ${{ matrix.php > '8.1' }}
-        run: composer update --ignore-platform-req=php+
-
-      - name: CGL check
-        if: ${{ matrix.php == '7.2' }}
-        run: vendor/bin/php-cs-fixer fix --dry-run
-
       - name: Phpstan
-        if: ${{ matrix.php < '8.0' }}
+        if: ${{ matrix.php == '8.1' }}
         run: vendor/bin/phpstan analyze --no-progress
 
       - name: Run test suite

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Install dependencies
         run: composer update
 
+      - name: CGL check
+        if: ${{ matrix.php == '8.1' }}
+        run: vendor/bin/php-cs-fixer fix --dry-run
+
       - name: Phpstan
         if: ${{ matrix.php == '8.1' }}
         run: vendor/bin/phpstan analyze --no-progress

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         php: ['8.1', '8.2', '8.3']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "Generates XSD schemas for packages containing Fluid ViewHelpers",
 	"license": ["MIT"],
 	"require": {
-		"php": "^7.2 || ^8.0"
+		"php": "^8.1"
 	},
 	"require-dev": {
 		"typo3fluid/fluid": "^2.6.10",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,14 +1,5 @@
 parameters:
 	ignoreErrors:
-		-
-			message: "#^Cannot access property \\$ownerDocument on DOMElement\\|false\\.$#"
-			count: 1
-			path: src/SchemaGenerator.php
-
-		-
-			message: "#^Cannot call method appendChild\\(\\) on DOMElement\\|false\\.$#"
-			count: 1
-			path: src/SchemaGenerator.php
 
 		-
 			message: "#^Cannot call method importNode\\(\\) on DOMDocument\\|null\\.$#"
@@ -18,9 +9,4 @@ parameters:
 		-
 			message: "#^Method TYPO3\\\\FluidSchemaGenerator\\\\SchemaGenerator\\:\\:addChildWithCData\\(\\) should return SimpleXMLElement but returns SimpleXMLElement\\|null\\.$#"
 			count: 1
-			path: src/SchemaGenerator.php
-
-		-
-			message: "#^SimpleXMLElement does not accept string\\.$#"
-			count: 8
 			path: src/SchemaGenerator.php

--- a/src/SchemaGenerator.php
+++ b/src/SchemaGenerator.php
@@ -117,16 +117,16 @@ class SchemaGenerator
             $tagName = $this->getTagNameForClass($documentation->getClass());
 
             $xsdElement = $xmlRootNode->addChild('xsd:element');
-            $xsdElement['name'] = $tagName;
+            $xsdElement->addAttribute('name', $tagName);
 
             $this->addDocumentation($documentation->getDescription(), $xsdElement);
 
             $xsdComplexType = $xsdElement->addChild('xsd:complexType');
-            $xsdComplexType['mixed'] = 'true';
+            $xsdComplexType->addAttribute('mixed', 'true');
             $xsdSequence = $xsdComplexType->addChild('xsd:sequence');
             $xsdAny = $xsdSequence->addChild('xsd:any');
-            $xsdAny['minOccurs'] = '0';
-            $xsdAny['maxOccurs'] = '1';
+            $xsdAny->addAttribute('minOccurs', '0');
+            $xsdAny->addAttribute('maxOccurs', '1');
 
             $this->addAttributes($documentation, $xsdComplexType);
         }
@@ -144,11 +144,11 @@ class SchemaGenerator
             $default = $argumentDefinition->getDefaultValue();
             $type = $argumentDefinition->getType();
             $xsdAttribute = $xsdElement->addChild('xsd:attribute');
-            $xsdAttribute['type'] = $this->convertPhpTypeToXsdType($type);
-            $xsdAttribute['name'] = $argumentDefinition->getName();
-            $xsdAttribute['default'] = var_export($default, true);
+            $xsdAttribute->addAttribute('type', $this->convertPhpTypeToXsdType($type));
+            $xsdAttribute->addAttribute('name', $argumentDefinition->getName());
+            $xsdAttribute->addAttribute('default', var_export($default, true));
             if ($argumentDefinition->isRequired()) {
-                $xsdAttribute['use'] = 'required';
+                $xsdAttribute->addAttribute('use', 'required');
             }
             $this->addDocumentation($argumentDefinition->getDescription(), $xsdAttribute);
         }

--- a/tests/Unit/SchemaGeneratorTest.php
+++ b/tests/Unit/SchemaGeneratorTest.php
@@ -78,13 +78,10 @@ class SchemaGeneratorTest extends TestCase
     }
 
     /**
-     * @return mixed
+     * @param mixed[] $arguments
      */
-    protected function callInaccessibleMethod()
+    protected function callInaccessibleMethod(object $instance, string $method, ...$arguments): mixed
     {
-        $arguments = func_get_args();
-        $instance = array_shift($arguments);
-        $method = array_shift($arguments);
         $method = new \ReflectionMethod($instance, $method);
         $method->setAccessible(true);
         return $method->invokeArgs($instance, $arguments);


### PR DESCRIPTION
Since Fluid doesn't support older PHP versions anymore, it is safe to remove
them here as well.